### PR TITLE
Add support for domain and local parts

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -20,7 +20,7 @@ func ExampleDiscover() {
 
 func ExampleHandler() {
 	h := wkd.Handler{
-		Discover: func(hash string) ([]*openpgp.Entity, error) {
+		Discover: func(hash, domain, localPart string) ([]*openpgp.Entity, error) {
 			stallmanHash, _ := wkd.HashAddress("rms@gnu.org")
 			if hash != stallmanHash {
 				return nil, wkd.ErrNotFound

--- a/example_test.go
+++ b/example_test.go
@@ -1,6 +1,7 @@
 package wkd_test
 
 import (
+	"context"
 	"io"
 	"log"
 	"net/http"
@@ -21,7 +22,7 @@ func ExampleDiscover() {
 
 func ExampleHandler() {
 	h := wkd.Handler{
-		Discover: func(hash, domain, localPart string) (io.Reader, error) {
+		Discover: func(_ context.Context, hash, domain, localPart string) (io.Reader, error) {
 			stallmanHash, _ := wkd.HashAddress("rms@gnu.org")
 			if hash != stallmanHash {
 				return nil, wkd.ErrNotFound

--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package wkd
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -11,7 +12,7 @@ type Handler struct {
 	// Discover retrieves keys for an address. If there's no key available for
 	// this address, ErrNotFound should be returned.
 	// The returned io.Reader should read the binary representation of an OpenPGP key
-	Discover func(hash, domain, local string) (io.Reader, error)
+	Discover func(ctx context.Context, hash, domain, local string) (io.Reader, error)
 }
 
 func (h *Handler) servePolicy(w http.ResponseWriter, r *http.Request) {
@@ -19,7 +20,8 @@ func (h *Handler) servePolicy(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) serveDiscovery(w http.ResponseWriter, r *http.Request, hash, domain, local string) {
-	pubkeys, err := h.Discover(hash, domain, local)
+	ctx := r.Context()
+	pubkeys, err := h.Discover(ctx, hash, domain, local)
 	if err == ErrNotFound {
 		http.NotFound(w, r)
 		return

--- a/server.go
+++ b/server.go
@@ -1,17 +1,17 @@
 package wkd
 
 import (
+	"io"
 	"net/http"
 	"strings"
-
-	"golang.org/x/crypto/openpgp"
 )
 
 // Handler is a HTTP WKD handler.
 type Handler struct {
 	// Discover retrieves keys for an address. If there's no key available for
 	// this address, ErrNotFound should be returned.
-	Discover func(hash, domain, local string) ([]*openpgp.Entity, error)
+	// The returned io.Reader should read the binary representation of an OpenPGP key
+	Discover func(hash, domain, local string) (io.Reader, error)
 }
 
 func (h *Handler) servePolicy(w http.ResponseWriter, r *http.Request) {
@@ -29,9 +29,7 @@ func (h *Handler) serveDiscovery(w http.ResponseWriter, r *http.Request, hash, d
 	}
 
 	w.Header().Set("Content-Type", "application/octet-string")
-	for _, e := range pubkeys {
-		e.Serialize(w)
-	}
+	io.Copy(w, pubkeys)
 }
 
 // ServeHTTP implements http.Handler.


### PR DESCRIPTION
From draft-09 of the WKD spech the client should include the domain and
local part of the email address in the request. Let's add support for
that.

If the domain is not provided in the url path we parse it from the
requested domain. So we add multi-domain support even if the advanced
mode of WKD is not being used.

Closes: #4